### PR TITLE
Clean up references to "token"

### DIFF
--- a/draft-thomson-webpush-vapid.md
+++ b/draft-thomson-webpush-vapid.md
@@ -340,10 +340,6 @@ Credentials are invalid if:
 * the public key used to sign the JWT doesn't match the one that was included in
   the creation of the push message.
 
-A push subscription that is not restricted to a particular key MAY still
-validate a JWT that is present, with the exception of the last check.  A push
-service MAY then reject a request if the JWT is found to be invalid.
-
 Note:
 
 : In theory, since the push service was given a public key, the push message

--- a/draft-thomson-webpush-vapid.md
+++ b/draft-thomson-webpush-vapid.md
@@ -341,8 +341,8 @@ Credentials are invalid if:
   the creation of the push message.
 
 A push subscription that is not restricted to a particular key MAY still
-validate a token that is present, except for the last check.  A push service MAY
-then reject a request if the token is found to be invalid.
+validate a JWT that is present, with the exception of the last check.  A push
+service MAY then reject a request if the JWT is found to be invalid.
 
 Note:
 

--- a/draft-thomson-webpush-vapid.md
+++ b/draft-thomson-webpush-vapid.md
@@ -318,8 +318,7 @@ Note:
 
 When a push subscription has been associated with an application server, the
 request for push message delivery MUST include proof of possession for the
-associated private key or token that was used when creating the push
-subscription.
+associated private key that was used when creating the push subscription.
 
 A push service MUST reject a message that omits mandatory credentials
 with a 401 (Unauthorized) status code.  A push service MAY reject a message


### PR DESCRIPTION
This was either in error, or could refer to "JWT" instead.

Closes #13.
