### PR TITLE
Refer to `dh` in the note rather than `p256dh`

### DIFF
--- a/draft-thomson-webpush-vapid.md
+++ b/draft-thomson-webpush-vapid.md
@@ -245,15 +245,15 @@ The `p256ecdsa` parameter includes an elliptic curve digital signature algorithm
 the URL- and filename-safe variant of base-64 [RFC4648] with padding removed.
 
 Note that with push message encryption [I-D.ietf-webpush-encryption], this
-results in two values in the Crypto-Key header field, one with the a `p256dh`
-key and another with a `p256ecdsa` key.
+results in two values in the Crypto-Key header field, one with the a `dh` key
+and another with a `p256ecdsa` key.
 
 Some implementations permit the same P-256 key to be used for signing and key
 exchange.  An application server MUST select a different private key for the key
-exchange (i.e., `p256dh`) and signing (i.e., `p256ecdsa`).  Though a push
-service is not obligated to check either parameter for every push message, a
-push service SHOULD reject push messages that have identical values for these
-parameters with a 400 (Bad Request) status code.
+exchange (i.e., `dh`) and signing (i.e., `p256ecdsa`).  Though a push service is
+not obligated to check either parameter for every push message, a push service
+SHOULD reject push messages that have identical values for these parameters with
+a 400 (Bad Request) status code.
 
 Editor's Note:
 


### PR DESCRIPTION
As this is the naming used by encryption-encoding-01:
    https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-01
